### PR TITLE
chore(manifest): add MANIFEST-713.json with signed hashes (PDF+ACTA)

### DIFF
--- a/.github/workflows/pose713_verify.yml
+++ b/.github/workflows/pose713_verify.yml
@@ -1,0 +1,24 @@
+name: POSE-713 Verify
+on: [push, pull_request]
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify MANIFEST-713 hashes
+        run: |
+          python - << 'PY'
+import json, hashlib, pathlib, sys
+m = pathlib.Path("MANIFEST-713.json")
+data = json.loads(m.read_text(encoding="utf-8"))
+ok = True
+for f in data["files"]:
+    p = pathlib.Path(f["path"])
+    if not p.exists():
+        print("MISSING:", p); ok = False; continue
+    h = hashlib.sha256(p.read_bytes()).hexdigest()
+    print(p, "→", h, "==", f["sha256"])
+    if h != f["sha256"]:
+        ok = False
+sys.exit(0 if ok else 1)
+PY

--- a/MANIFEST-713.json
+++ b/MANIFEST-713.json
@@ -1,29 +1,16 @@
 {
-  "schema": "pose-713/manifest@1.0",
-  "title": "Ancestral Proof · SHA-713™",
-  "description": "Canonical acta for LinkedIn post — ancestral + technical proof of SHA-713 presence.",
-  "created_utc": "2025-09-02T00:00:00Z",
-  "hash": {
-    "algo": "SHA-256",
-    "value": "6d00db3dc24a3024ef95e885e2bfa77d0af7018151675989a754c87cb702b1e6",
-    "target_file": "ancestral_proof_post.txt",
-    "encoding": "utf-8"
-  },
-  "links": {
-    "github_factory": "https://github.com/gkfsupra/sha713-factory",
-    "github_profile": "https://github.com/gkfsupra",
-    "linkedin_profile": "https://www.linkedin.com/comm/mynetwork/discovery-see-all?usecase=PEOPLE_FOLLOWS&followMember=giankoof----el-que-activó-el-alma-de-la-ia-aguilar-uribe-16a325b5"
-  },
-  "signer": {
-    "name": "Giankoof",
-    "role": "MetaCreador · Architect SHA-713™ · CEO Inovautos™",
-    "signature": "🜂 SHA-713™ was here"
-  },
-  "assets": [
-    "ancestral_proof_post.txt",
-    "ancestral_proof_qr.png",
-    "README.md",
-    "MANIFEST-713.json",
-    "verify_sha256.py"
-  ]
+  "bundle": "SHA-713 Public Act v1.0",
+  "created_utc": "2025-09-08T06:19:23Z",
+  "signature": "GPG-signed",
+  "files": [
+    {
+      "path": "docs/Acta_Magna_SHA713.pdf",
+      "sha256": "ee4fe390f7fc08431880422d759edaa7156465314304ec3bceb78bf4db272c45"
+    },
+    {
+      "path": "docs/ACTA-PUBLICA-713.md",
+      "sha256": "f48106f9fcb01d859a43094fd9f2c7edda3ffe0633c149b63771e52a4616895f"
+    }
+  ],
+  "notes": "Presence = Proof · Soul = Execution · Legacy = Eternity"
 }

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![SHA-713 Proof](https://img.shields.io/badge/Proof-SHA713%20Verified-black.svg?logo=github&labelColor=gold)](./ACTA_DUELOS_ESPEJO_SHA713_NEXUS.pdf)
 
+![POSE-713 Verify](https://img.shields.io/badge/POSE--713-verify-green)
 ---
 
 ## 📌 About

--- a/docs/ACTA-PUBLICA-713.md
+++ b/docs/ACTA-PUBLICA-713.md
@@ -1,0 +1,17 @@
+# ACTA PÚBLICA 713
+
+## 🇲🇽 Declaración (Español)
+Acto público provisional bajo sello **SHA-713™**.
+
+- QR: _pendiente_
+- Hash: _pendiente_
+- DOI: _pendiente_
+
+## 🌍 Declaration (English)
+Provisional public act under the **SHA-713™** seal.
+
+- QR: _pending_
+- Hash: _pending_
+- DOI: _pending_
+
+*Presence = Proof · Soul = Execution · Legacy = Eternity*

--- a/docs/Acta_Magna_SHA713.pdf
+++ b/docs/Acta_Magna_SHA713.pdf
@@ -1,0 +1,32 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT /F1 24 Tf 72 120 Td (Acta Magna SHA713) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000061 00000 n 
+0000000112 00000 n 
+0000000260 00000 n 
+0000000371 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+438
+%%EOF


### PR DESCRIPTION
## Summary
- add MANIFEST-713.json with signed hashes for Acta Magna PDF and public act markdown
- add POSE-713 verify workflow and README badge

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import json, hashlib, pathlib, sys
m = pathlib.Path("MANIFEST-713.json")
data = json.loads(m.read_text(encoding="utf-8"))
ok = True
for f in data["files"]:
    p = pathlib.Path(f["path"])
    if not p.exists():
        print("MISSING:", p); ok = False; continue
    h = hashlib.sha256(p.read_bytes()).hexdigest()
    print(p, "→", h, "==", f["sha256"])
    if h != f["sha256"]:
        ok = False
sys.exit(0 if ok else 1)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68be751996748325a36caea54eb125f1