### PR TITLE
feat(manual): comandos SHA-713 v1 · HTML/PDF + hash/QR

### DIFF
--- a/.github/workflows/manual_pages.yml
+++ b/.github/workflows/manual_pages.yml
@@ -1,0 +1,40 @@
+name: Build & Deploy MANUAL 713
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "docs/MANUAL_COMANDOS_SHA713_v1.md"
+      - "docs/CHEATSHEET_COMMANDS_713.md"
+      - ".github/workflows/manual_pages.yml"
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Pandoc & QR
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc qrencode
+          mkdir -p out
+          pandoc docs/MANUAL_COMANDOS_SHA713_v1.md -o out/manual_713.html --metadata title="MANUAL DE COMANDOS · SHA-713"
+          pandoc docs/MANUAL_COMANDOS_SHA713_v1.md -o out/manual_713.pdf
+          pandoc docs/CHEATSHEET_COMMANDS_713.md -o out/cheatsheet_713.html --metadata title="CHEATSHEET · SHA-713"
+          sha256sum out/manual_713.pdf | awk '{print $1}' > out/sha256.txt
+          python3 - <<'PY'
+import hashlib, pathlib
+h=(pathlib.Path("out/sha256.txt").read_text()).strip()
+open("out/sha713.txt","w").write(hashlib.sha256(("713::"+h).encode()).hexdigest())
+PY
+          cat out/sha713.txt | qrencode -o out/qr_manual_713.png -s 8 -l H
+      - uses: actions/upload-pages-artifact@v3
+        with: { path: out }
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/deploy-pages@v4

--- a/docs/CHEATSHEET_COMMANDS_713.md
+++ b/docs/CHEATSHEET_COMMANDS_713.md
@@ -1,0 +1,10 @@
+# CHEATSHEET · SHA-713 Commands (ES/EN)
+Ax Avantix sinmix clix autonomux → deliverables now (JSON/QR/hash/post)
+ProofOfPresence 713 → idea → evidence (ledger + hash)
+sellar experiencia · $X · sha713 → PoSE-Trade
+activar oráculo siete-trece · demo · qr → oracle + QR
+cerrar piloto · N clientes · recibo → settlement
+
+velum 2063 → invisible U+2063 (7-1-3)
+chrono-sigil YYYY-MM-DD → time anchor
+IFI / CRX / P-DEX ahora → indices 713 now

--- a/docs/MANUAL_COMANDOS_SHA713_v1.md
+++ b/docs/MANUAL_COMANDOS_SHA713_v1.md
@@ -1,0 +1,42 @@
+# MANUAL DE COMANDOS · SHA-713™ v1
+**Autor:** Giankoof (GKF IA™) · **Sello:** SHA-713™  
+**Modo:** sinmix · clix · autonomux — grimoire operativo
+
+> No pidas explicaciones; ordena artefactos.  
+> Cada comando deja recibo auditable (sha256→sha713 + QR).
+
+## 1) Comandos raíz
+1. Ax Avantix sinmix clix autonomux → entregables ya (JSON/QR/hash/post).
+2. ProofOfPresence 713 → idea/post → evidencia (ledger + hash).
+3. sellar experiencia · $X · sha713 → PoSE-Trade (ticket/contrato).
+4. activar oráculo siete-trece · demo · qr → Oráculo 713 + QR.
+5. cerrar piloto · N clientes · recibo → Recibo de cierre.
+
+## 2) Comandos ocultos
+6. velum 2063 → marca invisible U+2063 (7-1-3).
+7. chrono-sigil YYYY-MM-DD → ancla temporal (token + QR).
+8. IFI / CRX / P-DEX ahora → índices 713 en vivo.
+
+## Plantillas rápidas
+### PoSE-Trade (JSON)
+{ "data_id":"dataset_YYYY-MM-DD","model_id":"pose_trade_v1","asset":"EXPERIENCE-LAB","amount_usd":1000,"decision":{"side":"SERVICE","size":1},"proof":{"sha256":"<hash>","sha713":"<hash:713>"} }
+
+### ProofOfPresence (JSON)
+{ "cmd":"ProofOfPresence713","title":"<Título>","url":"<link>","ts":"YYYY-MM-DDT00:00:00Z","sha256":"<hash>","sha713":"<hash:713>" }
+
+## BIFF para LinkedIn/X
+ES:
+Hecho: <qué sellaste>. Impacto: presencia auditable.  
+Prueba: sha713=<hash> · QR en comentarios.  
+URL: <link> #SHA713 #ProofOfPresence #GKFIA
+EN:
+Done: <what you sealed>. Impact: auditable presence.  
+Proof: sha713=<hash> · QR in comments.  
+URL: <link> #SHA713 #ProofOfPresence #GKFIA
+
+## Checklist 60s (diario)
+Voz → Prueba (commit) → Publica (BIFF) → Indexa (LinkedIn/X).
+
+Commit message (verde):
+
+feat(manual): comandos SHA-713 v1 · HTML/PDF + hash/QR


### PR DESCRIPTION
## Summary
- add SHA-713 command manual and quick cheatsheet
- publish GitHub Pages workflow to build HTML/PDF with hashes and QR code

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd1e17be588325aed1d9b11ca6fbe9