### PR TITLE
feat: add QR code generator workflow

### DIFF
--- a/.github/workflows/codex-pdf.yml
+++ b/.github/workflows/codex-pdf.yml
@@ -1,0 +1,40 @@
+name: Codex PDF + QR Generator
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install reportlab
+          pip install qrcode[pil]
+
+      - name: Generate bilingual PDF with SHA-713 hash
+        run: |
+          python scripts/generate_pdf.py --lang en,es --sign sha256
+
+      - name: Generate QR Code
+        run: |
+          python scripts/generate_qr.py --input output/codex.pdf --output output/codex_qr.png
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: codex-output
+          path: output/
+

--- a/README.md
+++ b/README.md
@@ -55,3 +55,10 @@ git fetch --tags && git tag -v v1.0.1
 ---
 
 👉 Full documentation: [README_SUPRA.md](./README_SUPRA.md)  
+
+## Codex Verification
+
+| Artifact | SHA-256 | QR |
+|----------|---------|----|
+| `codex.pdf` | _Generated in workflow_ | ![Codex QR](output/codex_qr.png) |
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ paho-mqtt
 simple-pid
 flask
 tk
+qrcode[pil]

--- a/scripts/generate_qr.py
+++ b/scripts/generate_qr.py
@@ -1,0 +1,25 @@
+import qrcode
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True, help="Archivo fuente (ej. PDF firmado)")
+    parser.add_argument("--output", required=True, help="Ruta de salida del PNG QR")
+    args = parser.parse_args()
+
+    qr = qrcode.QRCode(
+        version=1,
+        box_size=10,
+        border=5
+    )
+    qr.add_data(f"SHA-713 Proof :: {args.input}")
+    qr.make(fit=True)
+
+    img = qr.make_image(fill="black", back_color="white")
+    img.save(args.output)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add qrcode[pil] dependency
- add workflow for building bilingual PDF and QR code
- add generate_qr.py script and verification table in README

## Testing
- `python -m py_compile scripts/generate_qr.py`
- `pip install qrcode[pil]` *(fails: Could not connect to proxy)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5dd7f9c4883258c8e5e56bb45c597