### PR TITLE
feat: automate README verification table

### DIFF
--- a/.github/workflows/codex-pdf.yml
+++ b/.github/workflows/codex-pdf.yml
@@ -1,40 +1,61 @@
-name: Codex PDF + QR Generator
+name: Codex PDF + QR + README Seal
 
 on:
   push:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: write  # necesario para autocommit
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
-      - name: Install dependencies
+      - name: Install deps
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install reportlab
           pip install qrcode[pil]
 
-      - name: Generate bilingual PDF with SHA-713 hash
+      # 1) Genera PDF bilingüe + firma
+      - name: Generate bilingual PDF
         run: |
-          python scripts/generate_pdf.py --lang en,es --sign sha256
+          python scripts/generate_pdf.py --lang en,es --sign sha256 --out output/codex.pdf
 
-      - name: Generate QR Code
+      # 2) Genera QR del PDF (ojo fractal)
+      - name: Generate QR
         run: |
           python scripts/generate_qr.py --input output/codex.pdf --output output/codex_qr.png
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+      # 3) Actualiza README con hashes + QR
+      - name: Update README (SHA-713 table)
+        run: |
+          python scripts/update_readme.py
+          echo "Changed files:"; git status --porcelain
+
+      # 4) Auto-commit (solo si hubo cambios)
+      - name: Commit README update
+        if: ${{ success() }}
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          name: codex-output
-          path: output/
+          commit_message: "chore(sha-713): refresh verification table in README"
+          commit_user_name: "GKF-Bot 713"
+          commit_user_email: "bot@gkf.supra"
+          branch: ${{ github.ref_name }}
+          file_pattern: |
+            README.md
+            output/**
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ git fetch --tags && git tag -v v1.0.1
 
 👉 Full documentation: [README_SUPRA.md](./README_SUPRA.md)  
 
-## Codex Verification
+<!-- SHA713:TABLE:BEGIN -->
+## 🔒 Tabla de Verificación
 
-| Artifact | SHA-256 | QR |
-|----------|---------|----|
-| `codex.pdf` | _Generated in workflow_ | ![Codex QR](output/codex_qr.png) |
+| Archivo | SHA-256 Hash | QR |
+|---|---|---|
+| `—` | `—` | (no artifacts) |
+<!-- SHA713:TABLE:END -->
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ simple-pid
 flask
 tk
 qrcode[pil]
+reportlab

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+update_readme.py — GKF IA™ · SHA-713™
+Genera/actualiza tabla de verificación en README.md con hashes SHA-256 y QR.
+Reemplaza el bloque entre <!-- SHA713:TABLE:BEGIN --> y <!-- SHA713:TABLE:END -->
+"""
+
+from pathlib import Path
+import hashlib
+import sys
+
+OUTPUT_DIR = Path("output")
+README = Path("README.md")
+BEGIN = "<!-- SHA713:TABLE:BEGIN -->"
+END   = "<!-- SHA713:TABLE:END -->"
+
+# extensiones a hashear; puedes ajustar
+HASH_EXTS = {".pdf", ".zip", ".md", ".json"}
+
+
+def sha256_of(file: Path) -> str:
+    h = hashlib.sha256()
+    with file.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def guess_qr_for(file: Path) -> Path | None:
+    """
+    Regla: si existe un PNG con el mismo stem + '_qr.png' o '<stem>.png' en output/,
+    lo enlazamos; si no, dejamos '(embed pending)'.
+    """
+    candidates = [OUTPUT_DIR / f"{file.stem}_qr.png", OUTPUT_DIR / f"{file.stem}.png"]
+    for c in candidates:
+        if c.exists():
+            return c
+    return None
+
+
+def build_table(rows: list[tuple[str, str, str]]) -> str:
+    header = (
+        "## 🔒 Tabla de Verificación\n\n"
+        "| Archivo | SHA-256 Hash | QR |\n"
+        "|---|---|---|\n"
+    )
+    body = "\n".join(
+        f"| `{path}` | `{h}` | {qr} |" for path, h, qr in rows
+    )
+    return header + body + "\n"
+
+
+def main() -> int:
+    if not README.exists():
+        print("ERROR: README.md no existe en el repo.", file=sys.stderr)
+        return 2
+
+    if not OUTPUT_DIR.exists():
+        print("WARN: 'output/' no existe; tabla quedará vacía.", file=sys.stderr)
+
+    # Construimos filas
+    rows: list[tuple[str, str, str]] = []
+    if OUTPUT_DIR.exists():
+        for f in sorted(OUTPUT_DIR.rglob("*")):
+            if f.is_file() and f.suffix.lower() in HASH_EXTS:
+                h = sha256_of(f)
+                qr = guess_qr_for(f)
+                qr_md = f"![QR]({qr.as_posix()})" if qr else "(embed pending)"
+                rows.append((f.as_posix(), h, qr_md))
+
+    # Si no hay filas, deja una línea informativa
+    if not rows:
+        rows.append(("—", "—", "(no artifacts)"))
+
+    table_md = build_table(rows)
+
+    # Leemos README y reemplazamos bloque
+    content = README.read_text(encoding="utf-8")
+    if BEGIN not in content or END not in content:
+        # Inserta bloque al final si faltan marcadores
+        new_content = f"{content.rstrip()}\n\n{BEGIN}\n{table_md}{END}\n"
+    else:
+        pre, rest = content.split(BEGIN, 1)
+        _, post = rest.split(END, 1)
+        new_content = f"{pre}{BEGIN}\n{table_md}{END}{post}"
+
+    if new_content != content:
+        README.write_text(new_content, encoding="utf-8")
+        print("README actualizado con tabla SHA-713.")
+        return 0
+
+    print("README sin cambios.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- add `scripts/update_readme.py` to generate SHA-256 hashes and link QR codes, updating README between markers
- insert SHA-713 table markers in README and include initial table
- expand codex-pdf workflow to run the updater and auto-commit results
- include reportlab dependency for PDF generation

## Testing
- `python scripts/update_readme.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5e04b840c8325bf959a7d51aaa4e1