### PR TITLE
feat(sha-713): unify seal+badge+table+release pipeline

### DIFF
--- a/.github/workflows/sha713-seal-and-release.yml
+++ b/.github/workflows/sha713-seal-and-release.yml
@@ -1,0 +1,92 @@
+name: SHA-713 · Seal & Release
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: write    # para autocommit y release
+
+jobs:
+  seal:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install qrcode[pil] reportlab
+
+      # 1) Genera PDF bilingüe firmado
+      - name: Generate bilingual PDF (signed)
+        run: |
+          mkdir -p output
+          python scripts/generate_pdf.py --lang en,es --sign sha256 --out output/codex.pdf
+
+      # 2) Genera QR del PDF
+      - name: Generate QR
+        run: |
+          python scripts/generate_qr.py --input output/codex.pdf --output output/codex_qr.png
+
+      # 3) Actualiza README (tabla + badge last_seal.json)
+      - name: Update README (table+badge)
+        run: |
+          python scripts/update_readme.py
+          echo "Changes:"; git status --porcelain
+
+      # 4) Autocommit si hubo cambios
+      - name: Auto-commit README/output
+        if: ${{ success() }}
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore(sha-713): seal artifacts, update verification table & badge"
+          file_pattern: |
+            README.md
+            output/**
+
+      # 5) Subir artefactos del run
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sha713-seal-${{ github.run_id }}
+          path: output/
+
+  release:
+    needs: seal
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare tag
+        id: prep
+        run: |
+          TS=$(date -u +"%Y%m%d-%H%M")
+          echo "tag=v0.7.13-seal-${TS}" >> $GITHUB_OUTPUT
+          echo "name=SHA-713 Seal ${TS}" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.prep.outputs.tag }}
+          name: ${{ steps.prep.outputs.name }}
+          body: |
+            **Proof of Symbolic Execution (SHA-713)**
+            - Bilingual PDF
+            - SHA-256 hashes
+            - QR fractal
+            - README verification table + live badge
+          files: |
+            output/codex.pdf
+            output/codex_qr.png
+            output/last_seal.json
+

--- a/README.md
+++ b/README.md
@@ -64,3 +64,5 @@ git fetch --tags && git tag -v v1.0.1
 | `—` | `—` | (no artifacts) |
 <!-- SHA713:TABLE:END -->
 
+![Last SHA-713 Seal](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/gkfsupra/sha713-factory/main/output/last_seal.json)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,2 @@
-paho-mqtt
-simple-pid
-flask
-tk
 qrcode[pil]
 reportlab

--- a/scripts/generate_qr.py
+++ b/scripts/generate_qr.py
@@ -1,25 +1,12 @@
-import qrcode
-import argparse
-
-
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--input", required=True, help="Archivo fuente (ej. PDF firmado)")
-    parser.add_argument("--output", required=True, help="Ruta de salida del PNG QR")
-    args = parser.parse_args()
-
-    qr = qrcode.QRCode(
-        version=1,
-        box_size=10,
-        border=5
-    )
-    qr.add_data(f"SHA-713 Proof :: {args.input}")
-    qr.make(fit=True)
-
-    img = qr.make_image(fill="black", back_color="white")
-    img.save(args.output)
-
-
-if __name__ == "__main__":
-    main()
+#!/usr/bin/env python3
+import qrcode, argparse
+p = argparse.ArgumentParser()
+p.add_argument("--input", required=True)
+p.add_argument("--output", required=True)
+args = p.parse_args()
+qr = qrcode.QRCode(version=1, box_size=10, border=4)
+qr.add_data(f"SHA-713 Proof :: {args.input}")
+qr.make(fit=True)
+qr.make_image(fill_color="black", back_color="white").save(args.output)
+print("QR generado:", args.output)
 

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -1,99 +1,60 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-update_readme.py — GKF IA™ · SHA-713™
-Genera/actualiza tabla de verificación en README.md con hashes SHA-256 y QR.
-Reemplaza el bloque entre <!-- SHA713:TABLE:BEGIN --> y <!-- SHA713:TABLE:END -->
-"""
-
 from pathlib import Path
-import hashlib
-import sys
+import hashlib, sys, json, datetime as dt
 
-OUTPUT_DIR = Path("output")
+OUTPUT = Path("output")
 README = Path("README.md")
-BEGIN = "<!-- SHA713:TABLE:BEGIN -->"
-END   = "<!-- SHA713:TABLE:END -->"
-
-# extensiones a hashear; puedes ajustar
+BEGIN, END = "<!-- SHA713:TABLE:BEGIN -->", "<!-- SHA713:TABLE:END -->"
 HASH_EXTS = {".pdf", ".zip", ".md", ".json"}
 
-
-def sha256_of(file: Path) -> str:
+def h256(p: Path) -> str:
     h = hashlib.sha256()
-    with file.open("rb") as f:
-        for chunk in iter(lambda: f.read(1024 * 1024), b""):
-            h.update(chunk)
+    with p.open("rb") as f:
+        for ch in iter(lambda: f.read(1024*1024), b""): h.update(ch)
     return h.hexdigest()
 
+def qr_for(p: Path):
+    cands = [OUTPUT/f"{p.stem}_qr.png", OUTPUT/f"{p.stem}.png"]
+    return next((c for c in cands if c.exists()), None)
 
-def guess_qr_for(file: Path) -> Path | None:
-    """
-    Regla: si existe un PNG con el mismo stem + '_qr.png' o '<stem>.png' en output/,
-    lo enlazamos; si no, dejamos '(embed pending)'.
-    """
-    candidates = [OUTPUT_DIR / f"{file.stem}_qr.png", OUTPUT_DIR / f"{file.stem}.png"]
-    for c in candidates:
-        if c.exists():
-            return c
-    return None
+def build_table(rows):
+    head = "## 🔒 Tabla de Verificación\n\n| Archivo | SHA-256 Hash | QR |\n|---|---|---|\n"
+    body = "\n".join(f"| `{a}` | `{h}` | {qr} |" for a,h,qr in rows)
+    return head + body + "\n"
 
+def stamp_badge():
+    OUTPUT.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schemaVersion": 1,
+        "label": "SHA-713 Seal",
+        "message": dt.datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC"),
+        "color": "gold"
+    }
+    (OUTPUT/"last_seal.json").write_text(json.dumps(payload), encoding="utf-8")
 
-def build_table(rows: list[tuple[str, str, str]]) -> str:
-    header = (
-        "## 🔒 Tabla de Verificación\n\n"
-        "| Archivo | SHA-256 Hash | QR |\n"
-        "|---|---|---|\n"
-    )
-    body = "\n".join(
-        f"| `{path}` | `{h}` | {qr} |" for path, h, qr in rows
-    )
-    return header + body + "\n"
-
-
-def main() -> int:
-    if not README.exists():
-        print("ERROR: README.md no existe en el repo.", file=sys.stderr)
-        return 2
-
-    if not OUTPUT_DIR.exists():
-        print("WARN: 'output/' no existe; tabla quedará vacía.", file=sys.stderr)
-
-    # Construimos filas
-    rows: list[tuple[str, str, str]] = []
-    if OUTPUT_DIR.exists():
-        for f in sorted(OUTPUT_DIR.rglob("*")):
+def main():
+    if not README.exists(): sys.exit("README.md no existe")
+    rows = []
+    if OUTPUT.exists():
+        for f in sorted(OUTPUT.rglob("*")):
             if f.is_file() and f.suffix.lower() in HASH_EXTS:
-                h = sha256_of(f)
-                qr = guess_qr_for(f)
+                h = h256(f)
+                qr = qr_for(f)
                 qr_md = f"![QR]({qr.as_posix()})" if qr else "(embed pending)"
                 rows.append((f.as_posix(), h, qr_md))
+    if not rows: rows = [("—","—","(no artifacts)")]
+    table = build_table(rows)
 
-    # Si no hay filas, deja una línea informativa
-    if not rows:
-        rows.append(("—", "—", "(no artifacts)"))
-
-    table_md = build_table(rows)
-
-    # Leemos README y reemplazamos bloque
     content = README.read_text(encoding="utf-8")
-    if BEGIN not in content or END not in content:
-        # Inserta bloque al final si faltan marcadores
-        new_content = f"{content.rstrip()}\n\n{BEGIN}\n{table_md}{END}\n"
+    if BEGIN in content and END in content:
+        pre, rest = content.split(BEGIN,1); _, post = rest.split(END,1)
+        content = f"{pre}{BEGIN}\n{table}{END}{post}"
     else:
-        pre, rest = content.split(BEGIN, 1)
-        _, post = rest.split(END, 1)
-        new_content = f"{pre}{BEGIN}\n{table_md}{END}{post}"
-
-    if new_content != content:
-        README.write_text(new_content, encoding="utf-8")
-        print("README actualizado con tabla SHA-713.")
-        return 0
-
-    print("README sin cambios.")
-    return 0
-
+        content = f"{content.rstrip()}\n\n{BEGIN}\n{table}{END}\n"
+    README.write_text(content, encoding="utf-8")
+    stamp_badge()
+    print("README + badge actualizados.")
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    main()
 


### PR DESCRIPTION
## Summary
- add verification table block & live badge marker in README
- slim requirements to QR and PDF deps
- add canonical QR generator and README updater scripts
- create seal-and-release workflow for QR, badge, table & release

## Testing
- `python -m py_compile scripts/update_readme.py scripts/generate_qr.py`
- `python scripts/update_readme.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5e25960788325a3a420a3ffeace23