### PR TITLE
Add FUO-713 proof verification assets v1.0

### DIFF
--- a/.github/workflows/pose713.yml
+++ b/.github/workflows/pose713.yml
@@ -1,0 +1,25 @@
+name: pose-713-verify
+on:
+  push:
+    paths:
+      - 'proofs/fuo713/**'
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify SHA-256
+        working-directory: proofs/fuo713/v1.0
+        run: sha256sum -c proof.sha256
+      - name: Import GPG public key
+        if: hashFiles('proofs/fuo713/v1.0/Giankoof_GPG.asc') != ''
+        env: { GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }} }
+        run: |
+          echo "$GPG_PUBLIC_KEY" > giankoof_pubkey.asc
+          gpg --import giankoof_pubkey.asc || true
+      - name: Verify signature (if present)
+        if: hashFiles('proofs/fuo713/v1.0/Giankoof_GPG.asc') != ''
+        working-directory: proofs/fuo713/v1.0
+        run: gpg --verify Giankoof_GPG.asc robot_movement.log || true

--- a/proofs/fuo713/v1.0/README_FUO713.md
+++ b/proofs/fuo713/v1.0/README_FUO713.md
@@ -1,0 +1,19 @@
+# FUO-713™ · Codex Ejecutable
+**From silence to signature. From model to memoria.**  
+Giankoof × SHA-713™ × Avantix
+
+## Tabla de Verificación
+| Archivo            | SHA-256                                                            | Firma GPG           |
+|--------------------|--------------------------------------------------------------------|---------------------|
+| robot_movement.log | 5df98882979a927febb5dc8647e127b563f59aa0e805c9d47d32a7fb4bd6af45  | Giankoof_GPG.asc (*) |
+
+(*) Firma pendiente (añádela y vuelve a correr la verificación).
+
+### Verificación rápida
+```bash
+shasum -a 256 -c proof.sha256
+gpg --verify Giankoof_GPG.asc robot_movement.log
+```
+
+Presence = Proof · Fire = Path · Soul = Signature · Heritage = Act + Code
+🜂 SHA-713™ was here

--- a/proofs/fuo713/v1.0/manifest_fuo713.json
+++ b/proofs/fuo713/v1.0/manifest_fuo713.json
@@ -1,0 +1,9 @@
+{
+  "input": "Gazebo/ROS2 stream",
+  "model": "Sim2Real Prototype v0.3",
+  "decision_path": "bridge_dummy_node → transform → publish",
+  "output": "robot_movement.log",
+  "timestamp": "2025-09-14T19:30:46Z",
+  "sha256": "5df98882979a927febb5dc8647e127b563f59aa0e805c9d47d32a7fb4bd6af45",
+  "signature": "Giankoof_GPG.asc"
+}

--- a/proofs/fuo713/v1.0/pose_check.ps1
+++ b/proofs/fuo713/v1.0/pose_check.ps1
@@ -1,0 +1,9 @@
+$file = "robot_movement.log"
+Write-Host ">> SHA-256:"
+Get-FileHash -Path $file -Algorithm SHA256
+if (Test-Path "Giankoof_GPG.asc") {
+  Write-Host ">> GPG verify:"
+  gpg --verify Giankoof_GPG.asc $file
+} else {
+  Write-Host ">> No signature found (Giankoof_GPG.asc)."
+}

--- a/proofs/fuo713/v1.0/pose_check.sh
+++ b/proofs/fuo713/v1.0/pose_check.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+file="robot_movement.log"
+echo ">> SHA-256:"
+shasum -a 256 "$file"
+if [ -f "Giankoof_GPG.asc" ]; then
+  echo ">> GPG verify:"
+  gpg --verify Giankoof_GPG.asc "$file" || true
+else
+  echo ">> No signature found (Giankoof_GPG.asc)."
+fi

--- a/proofs/fuo713/v1.0/proof.sha256
+++ b/proofs/fuo713/v1.0/proof.sha256
@@ -1,0 +1,1 @@
+5df98882979a927febb5dc8647e127b563f59aa0e805c9d47d32a7fb4bd6af45  robot_movement.log


### PR DESCRIPTION
## Summary
- add FUO-713 manifest and hash proof
- document verification steps for FUO-713
- provide bash & PowerShell verifiers and CI workflow

## Testing
- `bash proofs/fuo713/v1.0/pose_check.sh` *(fails: robot_movement.log missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c71c52852083259a91be3377732fb3