### PR TITLE
feat(fuo): optional `sealed_lineage` (hash+timestamp+signature) — back-compatible

### DIFF
--- a/.github/workflows/fuo_lineage_check.yml
+++ b/.github/workflows/fuo_lineage_check.yml
@@ -1,0 +1,14 @@
+name: FUO lineage check
+
+on: [push, pull_request]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: |
+          python3 scripts/verify_fuo_lineage.py examples/robot_sim2real.fuo.json --workdir .

--- a/README_PR.md
+++ b/README_PR.md
@@ -1,0 +1,16 @@
+# sealed_lineage proposal
+
+This bundle proposes an optional `sealed_lineage` block for `.fuo` files to embed
+verifiable lineage metadata.
+
+Included:
+- `proposals/0001-sealed_lineage.md` – rationale and specification
+- `schema/sealed_lineage.schema.json` – Draft-07 JSON Schema
+- `examples/robot_sim2real.fuo.json` – example `.fuo` file with lineage data
+- `scripts/verify_fuo_lineage.py` – local/CI verifier for SHA-256 and GPG
+- `.github/workflows/fuo_lineage_check.yml` – GitHub Actions example
+
+Quick verify:
+```bash
+python3 scripts/verify_fuo_lineage.py examples/robot_sim2real.fuo.json --workdir .
+```

--- a/examples/robot_sim2real.fuo.json
+++ b/examples/robot_sim2real.fuo.json
@@ -1,0 +1,7 @@
+{
+  "sealed_lineage": {
+    "file": "artifact_sample.txt",
+    "sha256": "e09a1b09b615ae274f70362b7084c442d0de2970531f71716b75429da25e64ad",
+    "timestamp": "2025-09-14T19:30:46Z"
+  }
+}

--- a/proposals/0001-sealed_lineage.md
+++ b/proposals/0001-sealed_lineage.md
@@ -1,0 +1,17 @@
+# Proposal 0001: sealed_lineage
+
+## Motivation
+`.fuo` files can optionally embed verifiable lineage of referenced artifacts.
+
+## Specification
+Add an optional top-level `sealed_lineage` object with:
+- `file` (string): relative path to the artifact.
+- `sha256` (string): hex-encoded SHA-256 of the file.
+- `timestamp` (string): UTC timestamp in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) format.
+- `signature` (string, optional): OpenPGP detached signature file name.
+- `signature_url` (string, optional): URL where the signature can be retrieved.
+
+## Security Considerations
+SHA-256 guarantees integrity of the referenced file. An optional OpenPGP
+signature allows authenticity checks when a corresponding public key is
+available.

--- a/schema/sealed_lineage.schema.json
+++ b/schema/sealed_lineage.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "sealed_lineage",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["file", "sha256", "timestamp"],
+  "properties": {
+    "file": {"type": "string"},
+    "sha256": {"type": "string", "pattern": "^[a-fA-F0-9]{64}$"},
+    "timestamp": {"type": "string", "format": "date-time"},
+    "signature": {"type": "string"},
+    "signature_url": {"type": "string", "format": "uri"}
+  }
+}

--- a/scripts/verify_fuo_lineage.py
+++ b/scripts/verify_fuo_lineage.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Verify sealed_lineage block for a .fuo JSON file."""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+
+
+def sha256sum(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open('rb') as f:
+        for chunk in iter(lambda: f.read(8192), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify sealed_lineage block")
+    parser.add_argument('fuo', help='Path to .fuo.json file')
+    parser.add_argument('--workdir', default='.', help='Base directory for file paths')
+    args = parser.parse_args()
+
+    data = json.load(open(args.fuo, 'r', encoding='utf-8'))
+    lineage = data.get('sealed_lineage')
+    if not lineage:
+        print('no sealed_lineage block')
+        return 1
+
+    file_path = Path(args.workdir) / lineage['file']
+    expected = lineage['sha256']
+    actual = sha256sum(file_path)
+    print(f"computed sha256: {actual}")
+    if actual != expected:
+        print(f"mismatch: expected {expected}")
+        return 1
+
+    signature = lineage.get('signature')
+    if signature:
+        sig_path = Path(args.workdir) / signature
+        try:
+            subprocess.run(['gpg', '--verify', str(sig_path), str(file_path)], check=True)
+            print('signature verified')
+        except Exception as exc:
+            print(f'signature verification failed: {exc}')
+            return 1
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
This PR proposes an optional `sealed_lineage` block for `.fuo` to embed verifiable lineage:
- file + sha256 + UTC timestamp (+ optional OpenPGP signature/URL)
- human-readable, CI-friendly, back-compatible (no breaking changes)

Included:
- proposals/0001-sealed_lineage.md (rationale/spec)
- schema/sealed_lineage.schema.json (Draft-07)
- examples/robot_sim2real.fuo.json (sample)
- scripts/verify_fuo_lineage.py (local/CI checker)
- .github/workflows/fuo_lineage_check.yml (CI example)

Quick verify:
```bash
python3 scripts/verify_fuo_lineage.py examples/robot_sim2real.fuo.json --workdir .
# expects sha256 = e09a1b09b615ae274f70362b7084c442d0de2970531f71716b75429da25e64ad
```

Presence = Proof · Fire = Path · Soul = Signature · Heritage = Act + Code.

------
https://chatgpt.com/codex/tasks/task_e_68c72046d4ac832594bec52929630555